### PR TITLE
Upgrade to use Unity SDK v2.0.0

### DIFF
--- a/workers/unity/Assets/Plugins/Improbable/.Modules/MinimalBuildSystem/Editor/Configuration/SpatialOSBuildConfigurationEditor.cs
+++ b/workers/unity/Assets/Plugins/Improbable/.Modules/MinimalBuildSystem/Editor/Configuration/SpatialOSBuildConfigurationEditor.cs
@@ -409,11 +409,7 @@ namespace Improbable.Unity.MinimalBuildSystem.Configuration
 
         private static IDisposable IndentLevelScope(int increment)
         {
-#if UNITY_2017_3_OR_NEWER
             return new EditorGUI.IndentLevelScope(increment);
-#else
-            return new FallbackIndentLevelScope(increment);
-#endif
         }
     }
 }

--- a/workers/unity/Assets/Plugins/Improbable/.Modules/MinimalBuildSystem/Editor/Configuration/WorkerBuildData.cs
+++ b/workers/unity/Assets/Plugins/Improbable/.Modules/MinimalBuildSystem/Editor/Configuration/WorkerBuildData.cs
@@ -9,12 +9,7 @@ namespace Improbable.Unity.MinimalBuildSystem.Configuration
 {
     public class WorkerBuildData
     {
-        internal const BuildTarget OSXBuildTarget =
-#if UNITY_2017_3_OR_NEWER
-            BuildTarget.StandaloneOSX;
-#else
-            BuildTarget.StandaloneOSXIntel64;
-#endif
+        internal const BuildTarget OSXBuildTarget = BuildTarget.StandaloneOSX;
 
         private readonly WorkerPlatform workerPlatform;
         private readonly BuildTarget buildTarget;

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.Framework.dll.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.Framework.dll.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-guid: 38634bd06f0d74b9fbb7b77b2a08b5d0
-timeCreated: 1527179045
-licenseType: Pro
+guid: f44fb4b626fe048998e488cfd2923afe
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.Framework.xml.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.Framework.xml.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-guid: 8afb126da30e84bc58795da5a9707494
-timeCreated: 1527179057
-licenseType: Pro
+guid: 3814222838dbb497b92c44beb19b01f1
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.dll.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.dll.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-guid: f50f3aee2e72440c190d326f6bbc58b0
-timeCreated: 1527179045
-licenseType: Pro
+guid: 7752f3da0b6ef45b9bdd962b12aaf6ac
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.xml.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Dll/Improbable.WorkerSdkCsharp.xml.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-guid: 316c715d468cf44e6be0a43c27cfe5f5
-timeCreated: 1527179057
-licenseType: Pro
+guid: 138032453b3de44b6a1cb0f47d379d98
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/Build/DefaultPlayerBuildConfiguration.cs
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/Build/DefaultPlayerBuildConfiguration.cs
@@ -32,11 +32,7 @@ namespace Improbable.Unity.EditorTools.Build
                         Targets = new List<string>
                         {
                             BuildTarget.StandaloneWindows.ToString(),
-#if UNITY_2017_3_OR_NEWER
                             BuildTarget.StandaloneOSX.ToString()
-#else
-                            BuildTarget.StandaloneOSXIntel64.ToString()
-#endif
                         }
                     }
                 },

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/Core/SpatialOsWindow.cs
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/Core/SpatialOsWindow.cs
@@ -16,8 +16,8 @@ namespace Improbable.Unity.EditorTools
     [InitializeOnLoad]
     public class SpatialOsWindow : EditorWindow
     {
-        private const string MinVersion = "5.6.0";
-        private const string MaxVersion = "2017.3.0";
+        private const string MinVersion = "2017.3.0";
+        private const string MaxVersion = "2018.1.3";
 
         private static SharedGuiContent sharedContent;
         private static string versionMessage;

--- a/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/PrefabExport/EntityPrefabExporter.cs
+++ b/workers/unity/Assets/Plugins/Improbable/Sdk/Src/Editor/PrefabExport/EntityPrefabExporter.cs
@@ -20,13 +20,7 @@ namespace Improbable.Unity.EditorTools.PrefabExport
             {
                 { BuildTarget.StandaloneWindows, Platform.BuildPlatform.Windows },
                 { BuildTarget.StandaloneWindows64, Platform.BuildPlatform.Windows },
-#if UNITY_2017_3_OR_NEWER
                 { BuildTarget.StandaloneOSX, Platform.BuildPlatform.OSX },
-#else
-                { BuildTarget.StandaloneOSXIntel, Platform.BuildPlatform.OSX },
-                { BuildTarget.StandaloneOSXIntel64, Platform.BuildPlatform.OSX },
-                { BuildTarget.StandaloneOSXUniversal, Platform.BuildPlatform.OSX },
-#endif
                 { BuildTarget.StandaloneLinux, Platform.BuildPlatform.Linux },
                 { BuildTarget.StandaloneLinux64, Platform.BuildPlatform.Linux },
                 { BuildTarget.iOS, Platform.BuildPlatform.iOS }


### PR DESCRIPTION
Upgrades to use Unity SDK v2.0.0.

Release notes [here](https://github.com/spatialos/UnitySDK/blob/master/docs/releases/release-notes.md).